### PR TITLE
Added a small method to return the last node

### DIFF
--- a/treeprint.go
+++ b/treeprint.go
@@ -30,6 +30,8 @@ type Tree interface {
 	// FindByValue finds a node whose value matches the provided one by reflect.DeepEqual,
 	// returns nil if not found.
 	FindByValue(value Value) Tree
+	//  returns the last node of a tree
+	FindLastNode() Tree
 	// String renders the tree or subtree as a string.
 	String() string
 	// Bytes renders the tree or subtree as byteslice.
@@ -41,6 +43,12 @@ type node struct {
 	Meta  MetaValue
 	Value Value
 	Nodes []*node
+}
+
+func (n *node) FindLastNode() Tree {
+	ns := n.Nodes
+	n = ns[len(ns)-1]
+	return n
 }
 
 func (n *node) AddNode(v Value) Tree {


### PR DESCRIPTION
First of all thank you for this library, it saved me a lot of time.

I wanted to use treeprint to take a list of file paths and echo it in the same way as the `tree` command does on Linux.

To make this work, I added a small method to return the last mode of a tree, named, FindLastNode().

```
	tree := treeprint.New()
	b = r.FilePaths()

	for _, path := range b {

		parts := strings.Split(path, string(os.PathSeparator))

		t := tree.FindByValue(parts[0])

		if t == nil {
			t = tree.AddBranch(parts[0])
		}

		for i := 1; i < len(parts); i++ {
			if i == 1 {
				t = t.AddNode(parts[1])
				continue
			}
			t = t.FindLastNode()
			t = t.AddNode(parts[i])
			t = t.FindLastNode()
		}

	}

	fmt.Println(tree.String())
```

It is possible the above behaviour could be done before with existing methods in the library but I wasn't able to discover how. 