### PR TITLE
Ability to name the root node something other than "."

### DIFF
--- a/treeprint.go
+++ b/treeprint.go
@@ -36,6 +36,8 @@ type Tree interface {
 	String() string
 	// Bytes renders the tree or subtree as byteslice.
 	Bytes() []byte
+
+	SetValue(value Value)
 }
 
 type node struct {
@@ -125,7 +127,7 @@ func (n *node) Bytes() []byte {
 	level := 0
 	var levelsEnded []int
 	if n.Root == nil {
-		buf.WriteString(string(EdgeTypeStart))
+		buf.WriteString(fmt.Sprintf("%v",n.Value))
 		buf.WriteByte('\n')
 	} else {
 		edge := EdgeTypeMid
@@ -143,6 +145,10 @@ func (n *node) Bytes() []byte {
 
 func (n *node) String() string {
 	return string(n.Bytes())
+}
+
+func (n *node) SetValue(value Value){
+	n.Value = value
 }
 
 func printNodes(wr io.Writer,
@@ -190,12 +196,11 @@ func isEnded(levelsEnded []int, level int) bool {
 type EdgeType string
 
 var (
-	EdgeTypeStart EdgeType = "."
 	EdgeTypeLink  EdgeType = "│"
 	EdgeTypeMid   EdgeType = "├──"
 	EdgeTypeEnd   EdgeType = "└──"
 )
 
 func New() Tree {
-	return &node{}
+	return &node{Value: "."}
 }

--- a/treeprint_test.go
+++ b/treeprint_test.go
@@ -62,6 +62,23 @@ func TestLevel(t *testing.T) {
 	assert.Equal(expected, actual)
 }
 
+func TestNamedRoot(t *testing.T) {
+	assert := assert.New(t)
+
+	tree := New()
+	tree.AddBranch("hello").AddNode("my friend").AddNode("lol")
+	tree.AddNode("world")
+	tree.SetValue("friends")
+	actual := tree.String()
+	expected := `friends
+├── hello
+│   ├── my friend
+│   └── lol
+└── world
+`
+	assert.Equal(expected, actual)
+}
+
 func TestDeepLevel(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
It would be useful if the root node could be named rather than always ".", that way the tree-view's usefulness can be extended to other domains.