### PR TITLE
Check slice length for FindLastNode() to prevent panic

### DIFF
--- a/treeprint.go
+++ b/treeprint.go
@@ -50,8 +50,10 @@ type node struct {
 
 func (n *node) FindLastNode() Tree {
 	ns := n.Nodes
-	n = ns[len(ns)-1]
-	return n
+	if len(ns) == 0 {
+		return nil
+	}
+	return ns[len(ns)-1]
 }
 
 func (n *node) AddNode(v Value) Tree {


### PR DESCRIPTION
The program is paniced when `FindlastNode()` is called on the root node.
https://play.golang.org/p/DxiDN05mWQl