### PR TITLE
Add custom root capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ When you want to render a complex data structure:
 
 ```go
 func main() {
+    // to add a custom root name use `treeprint.NewWithRoot()` instead
     tree := treeprint.New()
 
     // create a new branch in the root
@@ -90,6 +91,7 @@ Another case, when you have to make a tree where any leaf may have some meta-dat
 
 ```go
 func main {
+    // to add a custom root name use `treeprint.NewWithRoot()` instead
     tree := treeprint.New()
 
     tree.AddNode("Dockerfile")

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/xlab/treeprint
 
 go 1.13
+
+require github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/treeprint.go
+++ b/treeprint.go
@@ -261,6 +261,12 @@ var (
 // IndentSize is the number of spaces per tree level.
 var IndentSize = 3
 
+// New Generates new tree
 func New() Tree {
 	return &node{Value: "."}
+}
+
+// NewWithRoot Generates new tree with the given root value
+func NewWithRoot(root Value) Tree {
+	return &node{Value: root}
 }

--- a/treeprint_test.go
+++ b/treeprint_test.go
@@ -6,6 +6,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestZeroNodesWithRoot(t *testing.T) {
+	assert := assert.New(t)
+
+	tree := NewWithRoot("mytree")
+	actual := tree.String()
+	expected := "mytree\n"
+	assert.Equal(expected, actual)
+}
+
 func TestOneNode(t *testing.T) {
 	assert := assert.New(t)
 
@@ -13,6 +22,18 @@ func TestOneNode(t *testing.T) {
 	tree.AddNode("hello")
 	actual := tree.String()
 	expected := `.
+└── hello
+`
+	assert.Equal(expected, actual)
+}
+
+func TestOneNodeWithRoot(t *testing.T) {
+	assert := assert.New(t)
+
+	tree := NewWithRoot("mytree")
+	tree.AddNode("hello")
+	actual := tree.String()
+	expected := `mytree
 └── hello
 `
 	assert.Equal(expected, actual)


### PR DESCRIPTION
This enables setting up a custom root for the tree structure like:

```
tree := NewWithRoot("myroot").String()
```

```
myroot
├── one
│   ├── subnode1
│   ├── subnode2
│   ├── two
│   │   ├── subnode1
│   │   ├── subnode2
│   │   └── three
│   │       ├── subnode1
│   │       └── subnode2
│   └── subnode3
└── outernode
```