### PR TITLE
Make `node` a public type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+vendor/**
+.idea
+**/**.iml

--- a/treeprint.go
+++ b/treeprint.go
@@ -16,28 +16,28 @@ type Value interface{}
 type MetaValue interface{}
 
 // NodeVisitor function type for iterating over nodes
-type NodeVisitor func(item *node)
+type NodeVisitor func(item *Node)
 
 // Tree represents a tree structure with leaf-nodes and branch-nodes.
 type Tree interface {
-	// AddNode adds a new node to a branch.
+	// AddNode adds a new Node to a branch.
 	AddNode(v Value) Tree
-	// AddMetaNode adds a new node with meta value provided to a branch.
+	// AddMetaNode adds a new Node with meta value provided to a branch.
 	AddMetaNode(meta MetaValue, v Value) Tree
-	// AddBranch adds a new branch node (a level deeper).
+	// AddBranch adds a new branch Node (a level deeper).
 	AddBranch(v Value) Tree
-	// AddMetaBranch adds a new branch node (a level deeper) with meta value provided.
+	// AddMetaBranch adds a new branch Node (a level deeper) with meta value provided.
 	AddMetaBranch(meta MetaValue, v Value) Tree
-	// Branch converts a leaf-node to a branch-node,
-	// applying this on a branch-node does no effect.
+	// Branch converts a leaf-Node to a branch-Node,
+	// applying this on a branch-Node does no effect.
 	Branch() Tree
-	// FindByMeta finds a node whose meta value matches the provided one by reflect.DeepEqual,
+	// FindByMeta finds a Node whose meta value matches the provided one by reflect.DeepEqual,
 	// returns nil if not found.
 	FindByMeta(meta MetaValue) Tree
-	// FindByValue finds a node whose value matches the provided one by reflect.DeepEqual,
+	// FindByValue finds a Node whose value matches the provided one by reflect.DeepEqual,
 	// returns nil if not found.
 	FindByValue(value Value) Tree
-	//  returns the last node of a tree
+	//  returns the last Node of a tree
 	FindLastNode() Tree
 	// String renders the tree or subtree as a string.
 	String() string
@@ -48,19 +48,19 @@ type Tree interface {
 	SetMetaValue(meta MetaValue)
 
 	// VisitAll iterates over the tree, branches and nodes.
-	// If need to iterate over the whole tree, use the root node.
+	// If need to iterate over the whole tree, use the root Node.
 	// Note this method uses a breadth-first approach.
 	VisitAll(fn NodeVisitor)
 }
 
-type node struct {
-	Root  *node
+type Node struct {
+	Root  *Node
 	Meta  MetaValue
 	Value Value
-	Nodes []*node
+	Nodes []*Node
 }
 
-func (n *node) FindLastNode() Tree {
+func (n *Node) FindLastNode() Tree {
 	ns := n.Nodes
 	if len(ns) == 0 {
 		return nil
@@ -68,16 +68,16 @@ func (n *node) FindLastNode() Tree {
 	return ns[len(ns)-1]
 }
 
-func (n *node) AddNode(v Value) Tree {
-	n.Nodes = append(n.Nodes, &node{
+func (n *Node) AddNode(v Value) Tree {
+	n.Nodes = append(n.Nodes, &Node{
 		Root:  n,
 		Value: v,
 	})
 	return n
 }
 
-func (n *node) AddMetaNode(meta MetaValue, v Value) Tree {
-	n.Nodes = append(n.Nodes, &node{
+func (n *Node) AddMetaNode(meta MetaValue, v Value) Tree {
+	n.Nodes = append(n.Nodes, &Node{
 		Root:  n,
 		Meta:  meta,
 		Value: v,
@@ -85,8 +85,8 @@ func (n *node) AddMetaNode(meta MetaValue, v Value) Tree {
 	return n
 }
 
-func (n *node) AddBranch(v Value) Tree {
-	branch := &node{
+func (n *Node) AddBranch(v Value) Tree {
+	branch := &Node{
 		Root:  n,
 		Value: v,
 	}
@@ -94,8 +94,8 @@ func (n *node) AddBranch(v Value) Tree {
 	return branch
 }
 
-func (n *node) AddMetaBranch(meta MetaValue, v Value) Tree {
-	branch := &node{
+func (n *Node) AddMetaBranch(meta MetaValue, v Value) Tree {
+	branch := &Node{
 		Root:  n,
 		Meta:  meta,
 		Value: v,
@@ -104,12 +104,12 @@ func (n *node) AddMetaBranch(meta MetaValue, v Value) Tree {
 	return branch
 }
 
-func (n *node) Branch() Tree {
+func (n *Node) Branch() Tree {
 	n.Root = nil
 	return n
 }
 
-func (n *node) FindByMeta(meta MetaValue) Tree {
+func (n *Node) FindByMeta(meta MetaValue) Tree {
 	for _, node := range n.Nodes {
 		if reflect.DeepEqual(node.Meta, meta) {
 			return node
@@ -121,7 +121,7 @@ func (n *node) FindByMeta(meta MetaValue) Tree {
 	return nil
 }
 
-func (n *node) FindByValue(value Value) Tree {
+func (n *Node) FindByValue(value Value) Tree {
 	for _, node := range n.Nodes {
 		if reflect.DeepEqual(node.Value, value) {
 			return node
@@ -133,7 +133,7 @@ func (n *node) FindByValue(value Value) Tree {
 	return nil
 }
 
-func (n *node) Bytes() []byte {
+func (n *Node) Bytes() []byte {
 	buf := new(bytes.Buffer)
 	level := 0
 	var levelsEnded []int
@@ -158,19 +158,19 @@ func (n *node) Bytes() []byte {
 	return buf.Bytes()
 }
 
-func (n *node) String() string {
+func (n *Node) String() string {
 	return string(n.Bytes())
 }
 
-func (n *node) SetValue(value Value) {
+func (n *Node) SetValue(value Value) {
 	n.Value = value
 }
 
-func (n *node) SetMetaValue(meta MetaValue) {
+func (n *Node) SetMetaValue(meta MetaValue) {
 	n.Meta = meta
 }
 
-func (n *node) VisitAll(fn NodeVisitor) {
+func (n *Node) VisitAll(fn NodeVisitor) {
 	for _, node := range n.Nodes {
 		fn(node)
 
@@ -182,7 +182,7 @@ func (n *node) VisitAll(fn NodeVisitor) {
 }
 
 func printNodes(wr io.Writer,
-	level int, levelsEnded []int, nodes []*node) {
+	level int, levelsEnded []int, nodes []*Node) {
 
 	for i, node := range nodes {
 		edge := EdgeTypeMid
@@ -198,7 +198,7 @@ func printNodes(wr io.Writer,
 }
 
 func printValues(wr io.Writer,
-	level int, levelsEnded []int, edge EdgeType, node *node) {
+	level int, levelsEnded []int, edge EdgeType, node *Node) {
 
 	for i := 0; i < level; i++ {
 		if isEnded(levelsEnded, i) {
@@ -227,7 +227,7 @@ func isEnded(levelsEnded []int, level int) bool {
 	return false
 }
 
-func renderValue(level int, node *node) Value {
+func renderValue(level int, node *Node) Value {
 	lines := strings.Split(fmt.Sprintf("%v", node.Value), "\n")
 
 	// If value does not contain multiple lines, return itself.
@@ -248,10 +248,10 @@ func renderValue(level int, node *node) Value {
 
 // padding returns a padding for the multiline values with correctly placed link edges.
 // It is generated by traversing the tree upwards (from leaf to the root of the tree)
-// and, on each level, checking if the node the last one of its siblings.
-// If a node is the last one, the padding on that level should be empty (there's nothing to link to below it).
-// If a node is not the last one, the padding on that level should be the link edge so the sibling below is correctly connected.
-func padding(level int, node *node) string {
+// and, on each level, checking if the Node the last one of its siblings.
+// If a Node is the last one, the padding on that level should be empty (there's nothing to link to below it).
+// If a Node is not the last one, the padding on that level should be the link edge so the sibling below is correctly connected.
+func padding(level int, node *Node) string {
 	links := make([]string, level+1)
 
 	for node.Root != nil {
@@ -267,8 +267,8 @@ func padding(level int, node *node) string {
 	return strings.Join(links, "")
 }
 
-// isLast checks if the node is the last one in the slice of its parent children
-func isLast(n *node) bool {
+// isLast checks if the Node is the last one in the slice of its parent children
+func isLast(n *Node) bool {
 	return n == n.Root.FindLastNode()
 }
 
@@ -285,10 +285,10 @@ var IndentSize = 3
 
 // New Generates new tree
 func New() Tree {
-	return &node{Value: "."}
+	return &Node{Value: "."}
 }
 
 // NewWithRoot Generates new tree with the given root value
 func NewWithRoot(root Value) Tree {
-	return &node{Value: root}
+	return &Node{Value: root}
 }

--- a/treeprint_test.go
+++ b/treeprint_test.go
@@ -228,7 +228,7 @@ func TestRelationships(t *testing.T) {
 	foo.AddBranch("bar").AddNode("a").AddNode("b").AddNode("c")
 	foo.AddNode("end")
 
-	treeNode := tree.(*node)
+	treeNode := tree.(*Node)
 
 	assert.Nil(treeNode.Root)
 	assert.Len(treeNode.Nodes, 2)
@@ -307,7 +307,7 @@ func TestVisitAll(t *testing.T) {
 		"outernode",
 	}
 
-	tree.VisitAll(func(item *node) {
+	tree.VisitAll(func(item *Node) {
 		visitedNodeValues = append(visitedNodeValues, item.Value)
 	})
 


### PR DESCRIPTION
Resolves https://github.com/xlab/treeprint/issues/19

Make `node` a public type so that `VisitAll` actually works, whereas now it craps out because `node` is not a public type.